### PR TITLE
Pr review comments frank

### DIFF
--- a/.idea/dictionaries/ninovanhooff.xml
+++ b/.idea/dictionaries/ninovanhooff.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="ninovanhooff">
     <words>
+      <w>allprojects</w>
       <w>talkback</w>
     </words>
   </dictionary>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="maven" />
       <option name="url" value="https://jitpack.io" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Call `Q42Stats().runAsync(Context)` from anywhere in your app.
 class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        //Optionally set the log level, which is Error by default
-        //Q42Stats.logLevel = Q42StatsLogLevel.Debug
         Q42Stats(
             Q42StatsConfig(
                 fireBaseProject = "theProject",
@@ -46,6 +44,12 @@ class SampleApplication : Application() {
 This can be safely called from the main thread since all work (both collecting statistics and sending them to the server) are done on an IO thread. 
 
 It is safe to call this function multiple times, as it will exit immediately if it is already running or when a data collection interval has not passed yet.
+
+By default, Q42Stats only logs errors. For debugging purposes, set the log level before using Q42Stats:
+
+```
+Q42Stats.logLevel = Q42StatsLogLevel.Debug
+```
 
 ## Data collected
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ class SampleApplication : Application() {
         super.onCreate()
         Q42Stats(
             Q42StatsConfig(
-                fireBaseProject = "theProject",
-                firebaseCollection = "theCollection",
+                firebaseProjectId = "theProject",
+                firestoreCollectionId = "theCollection",
                 // wait at least 7.5 days between data collections. the extra .5 is for time-of-day randomization
                 minimumSubmitInterval = (60 * 60 * 24 * 7.5).toLong()
             )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://jitci.com/gh/Q42/Q42Stats.Android/svg)](https://jitci.com/gh/Q42/Q42Stats.Android)
 
 
-Collect stats for Q42 internal usage, shared accross multiple Android projects.
+Collect stats for Q42 internal usage, shared across multiple Android projects.
 
 An iOS version is also available: https://github.com/Q42/Q42Stats
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Call `Q42Stats().runAsync(Context)` from anywhere in your app.
 class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        //Optionally set the log level, which is Error by default
+        //Q42Stats.logLevel = Q42StatsLogLevel.Debug
         Q42Stats(
             Q42StatsConfig(
                 fireBaseProject = "theProject",

--- a/app/src/main/java/com/q42/q42stats/sample/SampleApplication.kt
+++ b/app/src/main/java/com/q42/q42stats/sample/SampleApplication.kt
@@ -10,8 +10,8 @@ class SampleApplication : Application() {
         super.onCreate()
         Q42Stats(
             Q42StatsConfig(
-                fireBaseProject = "theProject",
-                firebaseCollection = "theCollection",
+                firebaseProjectId = "theProject",
+                firebaseCollectionId = "theCollection",
                 // wait at least 7.5 days between data collections. the extra .5 is for time-of-day randomization
                 minimumSubmitIntervalSeconds = (60 * 60 * 24 * 7.5).toLong()
             )

--- a/app/src/main/java/com/q42/q42stats/sample/SampleApplication.kt
+++ b/app/src/main/java/com/q42/q42stats/sample/SampleApplication.kt
@@ -13,7 +13,7 @@ class SampleApplication : Application() {
                 fireBaseProject = "theProject",
                 firebaseCollection = "theCollection",
                 // wait at least 7.5 days between data collections. the extra .5 is for time-of-day randomization
-                minimumSubmitInterval = (60 * 60 * 24 * 7.5).toLong()
+                minimumSubmitIntervalSeconds = (60 * 60 * 24 * 7.5).toLong()
             )
         ).runAsync(this.applicationContext)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.4.32"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
+    implementation "androidx.annotation:annotation:1.2.0"
+
     testImplementation 'junit:junit:4.13.2'
     //json is included in Android, but not in Kotlin. This import makes it available for unit tests
     testImplementation 'org.json:json:20201115'

--- a/library/src/main/java/com/q42/q42stats/library/FireStoreUtils.kt
+++ b/library/src/main/java/com/q42/q42stats/library/FireStoreUtils.kt
@@ -15,7 +15,7 @@ import java.io.Serializable
  *     }
  * ```
  */
-fun Map<String, Serializable>.toFireStoreFormat(): JSONObject {
+internal fun Map<String, Serializable>.toFireStoreFormat(): JSONObject {
     val fireStoreMap = mapOf(
         "fields" to this.mapValues {
             mapOf("stringValue" to it.value.toString())

--- a/library/src/main/java/com/q42/q42stats/library/HttpService.kt
+++ b/library/src/main/java/com/q42/q42stats/library/HttpService.kt
@@ -30,7 +30,7 @@ internal object HttpService {
             conn.setRequestProperty("Content-Type", "application/json; charset=utf-8")
             sendPostRequestContent(conn, jsonObject)
         } catch (e: Throwable) {
-            throw Q42StatsException("Could not send stats to server", e)
+            Q42StatsLogger.e(TAG, "Could not send stats to server", e)
         }
     }
 
@@ -45,7 +45,7 @@ internal object HttpService {
             }
             Q42StatsLogger.d(TAG, "Response: ${conn.responseCode} ${conn.responseMessage}")
         } catch (e: Throwable) {
-            throw Q42StatsException("Could not add data to POST request", e)
+            Q42StatsLogger.e(TAG, "Could not add data to POST request", e)
         } finally {
             conn.disconnect()
         }

--- a/library/src/main/java/com/q42/q42stats/library/HttpService.kt
+++ b/library/src/main/java/com/q42/q42stats/library/HttpService.kt
@@ -24,13 +24,15 @@ internal object HttpService {
     }
 
     private fun httpPost(url: String, jsonObject: JSONObject) {
+        val conn = URL(url).openConnection() as HttpsURLConnection
         try {
-            val conn = URL(url).openConnection() as HttpsURLConnection
             conn.requestMethod = "POST"
             conn.setRequestProperty("Content-Type", "application/json; charset=utf-8")
             sendPostRequestContent(conn, jsonObject)
         } catch (e: Throwable) {
             Q42StatsLogger.e(TAG, "Could not send stats to server", e)
+        } finally {
+            conn.disconnect()
         }
     }
 
@@ -46,8 +48,6 @@ internal object HttpService {
             Q42StatsLogger.d(TAG, "Response: ${conn.responseCode} ${conn.responseMessage}")
         } catch (e: Throwable) {
             Q42StatsLogger.e(TAG, "Could not add data to POST request", e)
-        } finally {
-            conn.disconnect()
         }
     }
 }

--- a/library/src/main/java/com/q42/q42stats/library/HttpService.kt
+++ b/library/src/main/java/com/q42/q42stats/library/HttpService.kt
@@ -13,8 +13,8 @@ internal object HttpService {
 
     fun sendStatsSync(config: Q42StatsConfig, data: JSONObject) {
         sendStatsSync(
-            "https://firestore.googleapis.com/v1/projects/${config.fireBaseProject}/" +
-                    "databases/(default)/documents/${config.firebaseCollection}?mask.fieldPaths=_",
+            "https://firestore.googleapis.com/v1/projects/${config.firebaseProjectId}/" +
+                    "databases/(default)/documents/${config.firebaseCollectionId}?mask.fieldPaths=_",
             data
         )
     }

--- a/library/src/main/java/com/q42/q42stats/library/HttpService.kt
+++ b/library/src/main/java/com/q42/q42stats/library/HttpService.kt
@@ -1,5 +1,6 @@
 package com.q42.q42stats.library
 
+import androidx.annotation.WorkerThread
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.BufferedWriter
@@ -9,8 +10,9 @@ import java.net.HttpURLConnection
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 
+@WorkerThread
 object HttpService {
-    /** Synchronously send the stats. Make sure to run this on a worker thread */
+
     fun sendStatsSync(config: Q42StatsConfig, data: JSONObject) {
         sendStatsSync(
             "https://firestore.googleapis.com/v1/projects/${config.fireBaseProject}/" +

--- a/library/src/main/java/com/q42/q42stats/library/HttpService.kt
+++ b/library/src/main/java/com/q42/q42stats/library/HttpService.kt
@@ -9,7 +9,7 @@ import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 
 @WorkerThread
-object HttpService {
+internal object HttpService {
 
     fun sendStatsSync(config: Q42StatsConfig, data: JSONObject) {
         sendStatsSync(

--- a/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -1,6 +1,8 @@
 package com.q42.q42stats.library
 
 import android.content.Context
+import androidx.annotation.AnyThread
+import androidx.annotation.WorkerThread
 import com.q42.q42stats.library.collector.AccessibilityCollector
 import com.q42.q42stats.library.collector.PreferencesCollector
 import com.q42.q42stats.library.collector.SystemCollector
@@ -19,6 +21,7 @@ class Q42Stats(private val config: Q42StatsConfig) {
 
     /* Collects stats and sends it to the server. This method is safe to be called from anywhere
     in your app and will do nothing if it has already run before */
+    @AnyThread
     fun runAsync(context: Context) {
         Q42StatsLogger.d(TAG, "Q42Stats: Checking Preconditions")
         if (isRunning.get()) {
@@ -31,7 +34,7 @@ class Q42Stats(private val config: Q42StatsConfig) {
         GlobalScope.launch(Dispatchers.IO) { synchronized(MUTEX) { runSync(context) } }
     }
 
-    /** This should be run on a worker thread */
+    @WorkerThread
     private fun runSync(context: Context) {
         try {
             isRunning.set(true)

--- a/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -74,4 +74,13 @@ class Q42Stats(private val config: Q42StatsConfig) {
         collected += SystemCollector.collect()
         return collected
     }
+
+    companion object {
+        @Suppress("unused")
+        var logLevel: Q42StatsLogLevel
+            get() = Q42StatsLogger.logLevel
+            set(value) {
+                Q42StatsLogger.logLevel = value
+            }
+    }
 }

--- a/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -33,9 +33,7 @@ class Q42Stats(private val config: Q42StatsConfig) {
     private fun runSync(context: Context) {
         try {
             val prefs = Q42StatsPrefs(context)
-            if (prefs.withinSubmitInterval(config.minimumSubmitIntervalSeconds * 1000L)
-                && !BuildConfig.DEBUG
-            ) {
+            if (prefs.withinSubmitInterval(config.minimumSubmitIntervalSeconds * 1000L)) {
                 Q42StatsLogger.i(
                     TAG,
                     "Q42Stats were already sent in the last ${config.minimumSubmitIntervalSeconds} seconds."
@@ -77,6 +75,7 @@ class Q42Stats(private val config: Q42StatsConfig) {
                 Q42StatsLogger.logLevel = value
             }
 
+        /** A static job ensures that only a single instance of Q42Stats can be running */
         private var job: Job? = null
     }
 }

--- a/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -39,10 +39,12 @@ class Q42Stats(private val config: Q42StatsConfig) {
         try {
             isRunning.set(true)
             val prefs = Q42StatsPrefs(context)
-            if (prefs.withinSubmitInterval(config.minimumSubmitInterval * 1000L) && !BuildConfig.DEBUG) {
+            if (prefs.withinSubmitInterval(config.minimumSubmitIntervalSeconds * 1000L)
+                && !BuildConfig.DEBUG
+            ) {
                 Q42StatsLogger.i(
                     TAG,
-                    "Q42Stats were already sent in the last ${config.minimumSubmitInterval} seconds."
+                    "Q42Stats were already sent in the last ${config.minimumSubmitIntervalSeconds} seconds."
                 )
                 return
             }

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsConfig.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsConfig.kt
@@ -5,5 +5,5 @@ data class Q42StatsConfig(
     val firebaseCollection: String,
     /** Data collection is skipped when less than this many seconds have passed
      * since the previous run */
-    val minimumSubmitInterval: Long
+    val minimumSubmitIntervalSeconds: Long
 )

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsConfig.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsConfig.kt
@@ -1,8 +1,8 @@
 package com.q42.q42stats.library
 
 data class Q42StatsConfig(
-    val fireBaseProject: String,
-    val firebaseCollection: String,
+    val firebaseProjectId: String,
+    val firebaseCollectionId: String,
     /** Data collection is skipped when less than this many seconds have passed
      * since the previous run */
     val minimumSubmitIntervalSeconds: Long

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsException.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsException.kt
@@ -1,4 +1,0 @@
-package com.q42.q42stats.library
-
-internal class Q42StatsException(message: String, cause: Throwable) :
-    Throwable("$message: ${cause.message}", cause)

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsException.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsException.kt
@@ -1,0 +1,4 @@
+package com.q42.q42stats.library
+
+class Q42StatsException(message: String, cause: Throwable) :
+    Throwable("$message: ${cause.message}", cause)

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsException.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsException.kt
@@ -1,4 +1,4 @@
 package com.q42.q42stats.library
 
-class Q42StatsException(message: String, cause: Throwable) :
+internal class Q42StatsException(message: String, cause: Throwable) :
     Throwable("$message: ${cause.message}", cause)

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsLogger.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsLogger.kt
@@ -32,7 +32,7 @@ object Q42StatsLogger {
 
     fun e(tag: String, message: String, e: Throwable? = null) {
         if (logLevel <= LogLevel.Error) {
-            Log.e(tag, message, e)
+            Log.e(tag, "$message: ${e?.message}", e)
         }
     }
 }

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsLogger.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsLogger.kt
@@ -2,42 +2,42 @@ package com.q42.q42stats.library
 
 import android.util.Log
 
-object Q42StatsLogger {
+internal object Q42StatsLogger {
     /** logs with lower importance will be ignored */
-    private val logLevel = if (BuildConfig.DEBUG) LogLevel.Verbose else LogLevel.Info
+    var logLevel = if (BuildConfig.DEBUG) Q42StatsLogLevel.Verbose else Q42StatsLogLevel.Error
 
     fun v(tag: String, message: String) {
-        if (logLevel <= LogLevel.Verbose) {
+        if (logLevel <= Q42StatsLogLevel.Verbose) {
             Log.v(tag, message)
         }
     }
 
     fun d(tag: String, message: String) {
-        if (logLevel <= LogLevel.Debug) {
+        if (logLevel <= Q42StatsLogLevel.Debug) {
             Log.d(tag, message)
         }
     }
 
     fun i(tag: String, message: String) {
-        if (logLevel <= LogLevel.Info) {
+        if (logLevel <= Q42StatsLogLevel.Info) {
             Log.i(tag, message)
         }
     }
 
     fun w(tag: String, message: String) {
-        if (logLevel <= LogLevel.Warn) {
+        if (logLevel <= Q42StatsLogLevel.Warn) {
             Log.w(tag, message)
         }
     }
 
     fun e(tag: String, message: String, e: Throwable? = null) {
-        if (logLevel <= LogLevel.Error) {
+        if (logLevel <= Q42StatsLogLevel.Error) {
             Log.e(tag, "$message: ${e?.message}", e)
         }
     }
 }
 
-enum class LogLevel {
+enum class Q42StatsLogLevel {
     //Log levels in order of importance
     Verbose,
     Debug,

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
@@ -8,7 +8,7 @@ private const val SHARED_PREFS_NAME = "Q42StatsPrefs"
 private const val LAST_SUBMIT_TIMESTAMP_KEY = "lastSubmitTimestamp"
 private const val INSTALLATION_ID_KEY = "installationId"
 
-class Q42StatsPrefs(context: Context) {
+internal class Q42StatsPrefs(context: Context) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
 

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
@@ -21,20 +21,16 @@ class Q42StatsPrefs(context: Context) {
         System.currentTimeMillis() <
                 prefs.getLong(LAST_SUBMIT_TIMESTAMP_KEY, 0) + interval
 
-    fun updateSubmitTimestamp() {
-        prefs.edit().apply {
-            putLong(LAST_SUBMIT_TIMESTAMP_KEY, System.currentTimeMillis())
-            apply()
-        }
+    fun updateSubmitTimestamp() = with(prefs.edit()) {
+        putLong(LAST_SUBMIT_TIMESTAMP_KEY, System.currentTimeMillis())
+        apply()
     }
 
-    private fun createInstallationId(): String {
-        prefs.edit().apply {
-            val uuid = UUID.randomUUID().toString()
-            putString(INSTALLATION_ID_KEY, uuid)
-            apply()
-            return uuid
-        }
+    private fun createInstallationId(): String = with(prefs.edit()) {
+        val uuid = UUID.randomUUID().toString()
+        putString(INSTALLATION_ID_KEY, uuid)
+        apply()
+        return uuid
     }
 
 }

--- a/library/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
+++ b/library/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
@@ -22,14 +22,14 @@ class Q42StatsPrefs(context: Context) {
                 prefs.getLong(LAST_SUBMIT_TIMESTAMP_KEY, 0) + interval
 
     fun updateSubmitTimestamp() {
-        prefs.edit().apply() {
+        prefs.edit().apply {
             putLong(LAST_SUBMIT_TIMESTAMP_KEY, System.currentTimeMillis())
             apply()
         }
     }
 
     private fun createInstallationId(): String {
-        prefs.edit().apply() {
+        prefs.edit().apply {
             val uuid = UUID.randomUUID().toString()
             putString(INSTALLATION_ID_KEY, uuid)
             apply()

--- a/library/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
+++ b/library/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
@@ -14,7 +14,7 @@ import java.io.Serializable
 import java.util.*
 
 /** Collects Accessibility-related settings and preferences, such as font scaling */
-object AccessibilityCollector {
+internal object AccessibilityCollector {
 
     fun collect(context: Context) = mutableMapOf<String, Serializable>().apply {
         val accessibilityManager =

--- a/library/src/main/java/com/q42/q42stats/library/collector/PreferencesCollector.kt
+++ b/library/src/main/java/com/q42/q42stats/library/collector/PreferencesCollector.kt
@@ -6,7 +6,7 @@ import com.q42.q42stats.library.util.DayTimeUtil
 import java.io.Serializable
 
 /** Collects System settings such as default locale */
-object PreferencesCollector {
+internal object PreferencesCollector {
 
     fun collect(context: Context) = mutableMapOf<String, Serializable>().apply {
         val configuration = context.resources.configuration

--- a/library/src/main/java/com/q42/q42stats/library/collector/SystemCollector.kt
+++ b/library/src/main/java/com/q42/q42stats/library/collector/SystemCollector.kt
@@ -4,7 +4,7 @@ import java.io.Serializable
 import java.util.*
 
 /** Collects System settings such as default locale */
-object SystemCollector {
+internal object SystemCollector {
 
     fun collect() = mutableMapOf<String, Serializable>().apply {
         put("defaultLanguage", Locale.getDefault().language) // language code like en or nl

--- a/library/src/main/java/com/q42/q42stats/library/util/DayTimeUtil.kt
+++ b/library/src/main/java/com/q42/q42stats/library/util/DayTimeUtil.kt
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.TestOnly
 import java.util.*
 import kotlin.math.abs
 
-object DayTimeUtil {
+internal object DayTimeUtil {
 
     // Real hacky function for determining day/night/twilight
     // With very wide margin (3 hours), because we don't know how

--- a/library/src/main/java/com/q42/q42stats/library/util/DayTimeUtil.kt
+++ b/library/src/main/java/com/q42/q42stats/library/util/DayTimeUtil.kt
@@ -6,7 +6,7 @@ import kotlin.math.abs
 
 object DayTimeUtil {
 
-    // Real hacky function for determening day/night/twilight
+    // Real hacky function for determining day/night/twilight
     // With very wide margin (3 hours), because we don't know how
     // Android implements this for Dark mode switch
     // Source: https://github.com/Q42/Q42Stats/blob/master/Sources/Q42Stats/Q42Stats.swift


### PR DESCRIPTION
I processed all of Frank's feedback.

- Not sure what exception-handling style you were suggesting. I wrapped expetions in some places with a more helpful message, 
  but tbh, I don't really see the benefit as all exceptions are fatal, and wrapping just obscures the root cause imho

- Interested to hear what you think about the coroutines-strategy. I also have an alternative where runAsync is a suspend fun. I am not sure what scope de actual work is done in though. I also like it less because it is less user-friendly for implementers. See https://github.com/Q42/Q42Stats.Android/blob/suspend-runAsync/library/src/main/java/com/q42/q42stats/library/Q42Stats.kt
- When I did not implement the suggested change, I replied to the suggestions in https://github.com/Q42/Q42Stats.Android/pull/2
- Kotlin lib 101: change visibility of non-public classes to `internal` :-)