### PR TITLE
Bug: no update of submit interval after json parsing error

### DIFF
--- a/q42stats/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -70,12 +70,11 @@ class Q42Stats(private val config: Q42StatsConfig) {
                 val batchId = it.getString("batchId") // throws if not found
                 prefs.lastBatchId = batchId
                 prefs.previousMeasurement = currentMeasurement
-                prefs.updateSubmitTimestamp()
             }
-
         } catch (e: Throwable) {
             handleException(e)
         } finally {
+            prefs.updateSubmitTimestamp() // make sure to always update the submit timestamp
             Q42StatsLogger.i(TAG, "Q42Stats: Exit")
         }
     }


### PR DESCRIPTION
**Problem**
An exception is thrown while parsing the response of `HttpService.sendStatsSync` (field 'batchId' is missing). This results in `updateSubmitTimestamp` not being invoked.

**Solution**
Move invocation of `updateSubmitTimestamp` to the `finally` block.