### PR TITLE
Bugfix/float serialization inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Q42Stats.Android 
+# Q42Stats.Android
+
 [![Release](https://jitpack.io/v/Q42/Q42Stats.Android.svg)](https://jitpack.io/#Q42/Q42Stats.Android)
 [![](https://jitci.com/gh/Q42/Q42Stats.Android/svg)](https://jitci.com/gh/Q42/Q42Stats.Android)
-
 
 Collect stats for Q42 internal usage, shared across multiple Android projects.
 
 An iOS version is also available: https://github.com/Q42/Q42Stats
 
 ## Installation
+
 Add the Jitpack repo and include the library:
 
 ```gradle
@@ -43,30 +44,44 @@ Add the Jitpack repo and include the library:
         }
     }
     ```
-    This can be safely called from the main thread since all work (both collecting statistics and sending them to the server) are done on an IO thread. 
+    This can be safely called from the main thread since all work (both collecting statistics and sending them to the server) are done on an IO thread.
 
-    It is safe to call this function multiple times, as it will exit immediately if it is already running or when a data collection interval has not passed yet.
+   It is safe to call this function multiple times, as it will exit immediately if it is already
+   running or when a data collection interval has not passed yet.
 
 ### Debug Logging
-By default, Q42Stats only logs errors. For debugging purposes, set the log level before using Q42Stats:
+
+By default, Q42Stats only logs errors. For debugging purposes, set the log level before using
+Q42Stats:
 
 ```
 Q42Stats.logLevel = Q42StatsLogLevel.Debug
 ```
 
+## Performance
+
+- Q42Stats is tiny, because it only depends on Kotlin. The library size is about 50kB.
+- Data consumption is also very modest. For each `minimumSubmitInterval` that you configure, about
+  5kB of data is transferred.
+- Data collection is run on an IO thread, so it doesn't block your application.
+
 ## Data collected
 
-Not all fields are supported on all versions of Android. If unsupported, the corresponding key is omitted.
+Q42Stats does not collect any personally identifiably information and is fully GDPR compliant. This
+has been verified by legal counsel. It should not be necesaary to ask users for permission before
+invoking Q42Stats.
+
+Below is a listing of all information gathered by Q42Stats. Not all fields are supported on all
+versions of Android. If unsupported, the corresponding key is omitted.
 
 ### Accessibliity
 
-| Key | Value | Notes |
-|-|-|-|
-| `isAccessibilityManagerEnabled` | bool | true when any accessibility service (eg. Talkback) is Enabled | 
-| `isClosedCaptioningEnabled` | bool | Live transcription of any spoken audio (min sdk 19) |
-| `isTouchExplorationEnabled` | bool | Whether any assistive feature is enabled where the user navigates the interface by touch. Most probably TalkbBack, or similar
-| `isTalkBackEnabled` | bool | iOS: VoiceOver
-| `isSamsungTalkBackEnabled` | bool | Specifically checks whether com.samsung.android.app.talkback.talkbackservice is enabled
+| Key | Value | Notes | |-|-|-| | `isAccessibilityManagerEnabled` | bool | true when any
+accessibility service (eg. Talkback) is Enabled | | `isClosedCaptioningEnabled` | bool | Live
+transcription of any spoken audio (min sdk 19) | | `isTouchExplorationEnabled` | bool | Whether any
+assistive feature is enabled where the user navigates the interface by touch. Most probably
+TalkbBack, or similar | `isTalkBackEnabled` | bool | iOS: VoiceOver | `isSamsungTalkBackEnabled` |
+bool | Specifically checks whether com.samsung.android.app.talkback.talkbackservice is enabled
 | `isSelectToSpeakEnabled` | bool | iOS: Speak Selection
 | `isSwitchAccessEnabled` | bool | Control the device by a switch such as a foot pedal
 | `isBrailleBackEnabled` | bool | Navigate the screen with an external Braille display

--- a/README.md
+++ b/README.md
@@ -129,12 +129,26 @@ bool | Specifically checks whether com.samsung.android.app.talkback.talkbackserv
 
 ### Publishing
 
-This library is distributed using [JitPack](https://jitpack.io/#q42/q42stats.android). This makes publishing a new version very easy:
+This library is distributed using [JitPack](https://jitpack.io/#q42/q42stats.android). This makes
+publishing a new version very easy:
 
 1. In `Q42Stats.kt`, increment `DATA_MODEL_VERSION` by 1 if any changes to collected data is made.
 1. Push the code for the new version to the `main` branch
-1. Unit tests will be run automatically. Check [JitCI](https://jitci.com/gh/Q42/Q42Stats.Android) for status
+1. Unit tests will be run automatically. Check [JitCI](https://jitci.com/gh/Q42/Q42Stats.Android)
+   for status
 1. Create a tag in the semver format: `x.x.x` without the preceding `v.`
 1. On GitHub, create a release from that tag. Give it the same name; `x.x.x`
-1. If everything went well the release will be visible on [JitPack](https://jitpack.io/#q42/q42stats.android) and the version number in the badge at the top of this page will update.
-1. In the Sample app build.gradle, Change the line `jitpackImplementation 'com.github.q42:q42stats.android:x.x.x` to the latest version.
+1. If everything went well the release will be visible
+   on [JitPack](https://jitpack.io/#q42/q42stats.android) and the version number in the badge at the
+   top of this page will update.
+1. In the Sample app build.gradle, Change the
+   line `jitpackImplementation 'com.github.q42:q42stats.android:x.x.x` to the latest version.
+
+### Troubleshooting
+
+- JitCi build failing while it can be successfully built locally
+
+  Perhaps something is broken in JitCi. JitPack can also be used for building and might be more
+  stable. To disable JitCi, select "Stop Building"
+  in [JitCi's](https://jitci.com/gh/Q42/Q42Stats.Android) settings page You will lose thebuild
+  status indicators in GitHub, however

--- a/README.md
+++ b/README.md
@@ -107,24 +107,36 @@ bool | Specifically checks whether com.samsung.android.app.talkback.talkbackserv
 
 ### System
 
-| Key | Value | Notes |
-|-|-|-|
-| `applicationId` | String | identifier for the app for which data is collected, as set in the app's Manifest. iOS: bundleId | nl.hema.mobiel |
-| `defaultLanguage`| en, nl, ... |
-| `sdkVersion` | int | 29 for Android 10. [See this list](https://source.android.com/setup/start/build-numbers)
-|`manufacturer`|String|eg. `samsung`|
-|`modelName`|String| May be a marketing name, but more often an internal code name. eg. `SM-G980F` for a particular variant of a Samsung Galaxy S10|
-
+| Key | Value | Notes | |-|-|-| | `applicationId` | String | identifier for the app for which data
+is collected, as set in the app's Manifest. iOS: bundleId | nl.hema.mobiel | | `defaultLanguage`|
+en, nl, ... | | `sdkVersion` | int | 29 for Android
+10. [See this list](https://source.android.com/setup/start/build-numbers)
+|`manufacturer`|String|eg. `samsung`| |`modelName`|String| May be a marketing name, but more often
+an internal code name. eg. `SM-G980F` for a particular variant of a Samsung Galaxy S10|
 
 ## Development
 
+All classes and functions that are not used by implementing apps should have `internal` visibility.
+
+Since this a library, all errors should be caught so that implementing apps don't crash. During
+development, you can use the debug flavors to allow the sample app to crash in cause of an
+Exception (see `handleException()`). When testing, use the release variants to make sure that
+exceptions don't crash the implementing apps.
+
+Catch Throwable; not Exception. Since Throwabl is the superclass of Exception, this will make the
+lib more resilient to crashes.
+
 ### Setup
-1. Get the API key from [The Api project](https://github.com/Q42/accessibility-pipeline/tree/main/api). Use this key in the next step.
-2. Create a file called `secrets.properties` in the root of the project (not in the app folder). Contents:
+
+1. Get the API key
+   from [The Api project](https://github.com/Q42/accessibility-pipeline/tree/main/api). Use this key
+   in the next step.
+2. Create a file called `secrets.properties` in the root of the project (not in the app folder).
+   Contents:
     ```
     apikey="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     ```
-    Note that this file will be ignored by git.
+   Note that this file will be ignored by git.
 3. Change the SampleApplication to construct a Q42Stats object for a real firestore collection.
 
 ### Publishing

--- a/q42stats/src/main/java/com/q42/q42stats/library/HttpService.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/HttpService.kt
@@ -1,7 +1,6 @@
 package com.q42.q42stats.library
 
 import androidx.annotation.WorkerThread
-import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.InputStreamReader
@@ -14,18 +13,18 @@ import javax.net.ssl.HttpsURLConnection
 internal object HttpService {
 
     /** Sends stats and returns body as String if successful */
-    fun sendStatsSync(config: Q42StatsConfig, data: JSONObject, lastBatchId: String?): JSONObject? =
+    fun sendStatsSync(config: Q42StatsConfig, data: String, lastBatchId: String?): String? =
         httpPost(
             "https://q42stats.ew.r.appspot.com/add/${config.firestoreCollectionId}",
             data,
             config.apiKey,
             lastBatchId
-        )?.let { JSONObject(it) }
+        )
 }
 
 private fun httpPost(
     url: String,
-    jsonObject: JSONObject,
+    data: String,
     apiKey: String,
     lastBatchId: String?
 ): String? {
@@ -43,7 +42,7 @@ private fun httpPost(
         lastBatchId?.let {
             conn.setRequestProperty("batchId", it)
         }
-        return sendPostRequestContent(conn, jsonObject)
+        return sendPostRequestContent(conn, data)
     } catch (e: Throwable) {
         Q42StatsLogger.e(TAG, "Could not send stats to server", e)
     } finally {
@@ -53,12 +52,12 @@ private fun httpPost(
     return null
 }
 
-private fun sendPostRequestContent(conn: HttpURLConnection, jsonObject: JSONObject): String? {
+private fun sendPostRequestContent(conn: HttpURLConnection, data: String): String? {
     try {
         conn.outputStream.use { os ->
             BufferedWriter(OutputStreamWriter(os, "UTF-8")).use { writer ->
-                writer.write(jsonObject.toString())
-                Q42StatsLogger.d(TAG, "Sending JSON: $jsonObject")
+                writer.write(data.toString())
+                Q42StatsLogger.d(TAG, "Sending JSON: $data")
                 writer.flush()
             }
         }

--- a/q42stats/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -77,8 +77,8 @@ class Q42Stats(private val config: Q42StatsConfig) {
                 prefs.lastBatchId = batchId
                 prefs.previousMeasurement = currentMeasurement
                     .toQ42StatsApiFormat()
-                    .let { q42StatsPrevMeasurement ->
-                        serializeMeasurement(q42StatsPrevMeasurement)
+                    .let { q42StatsCurrentMeasurement ->
+                        serializeMeasurement(q42StatsCurrentMeasurement)
                     }
                 prefs.updateSubmitTimestamp()
             }

--- a/q42stats/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/Q42StatsPrefs.kt
@@ -2,8 +2,6 @@ package com.q42.q42stats.library
 
 import android.content.Context
 import android.content.SharedPreferences
-import org.json.JSONArray
-import org.json.JSONObject
 
 private const val SHARED_PREFS_NAME = "Q42StatsPrefs"
 private const val LAST_SUBMIT_TIMESTAMP_KEY = "lastSubmitTimestamp"
@@ -14,14 +12,12 @@ internal class Q42StatsPrefs(context: Context) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
 
-    var previousMeasurement: Map<String, Any?>?
+    var previousMeasurement: String?
         get() =
-            prefs.getString(PREVIOUS_MEASUREMENT_KEY, null)?.let {
-                JSONObject(it).toMap()
-            }
+            prefs.getString(PREVIOUS_MEASUREMENT_KEY, null)
         set(value) = with(prefs.edit()) {
             value?.let {
-                putString(PREVIOUS_MEASUREMENT_KEY, JSONObject(value).toString())
+                putString(PREVIOUS_MEASUREMENT_KEY, value)
             } ?: run {
                 remove(PREVIOUS_MEASUREMENT_KEY)
             }
@@ -46,18 +42,6 @@ internal class Q42StatsPrefs(context: Context) {
     fun updateSubmitTimestamp() = with(prefs.edit()) {
         putLong(LAST_SUBMIT_TIMESTAMP_KEY, System.currentTimeMillis())
         apply()
-    }
-
-    private fun JSONObject.toMap(): Map<String, Any?> = keys().asSequence().associateWith {
-        when (val value = this[it]) {
-            is JSONArray -> {
-                val map = (0 until value.length()).associate { Pair(it.toString(), value[it]) }
-                JSONObject(map).toMap().values.toList()
-            }
-            is JSONObject -> value.toMap()
-            JSONObject.NULL -> null
-            else -> value
-        }
     }
 
 }

--- a/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
@@ -124,7 +124,7 @@ internal object AccessibilityCollector {
             name,
             0
         ) == 1
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
         Q42StatsLogger.e(TAG, "Could not read system int $name. Returning null", e)
         null
     }

--- a/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
@@ -2,7 +2,7 @@ package com.q42.q42stats.library
 
 import java.io.Serializable
 
-internal fun Map<String, Any>.toQ42StatsApiFormat(): Map<String, Any> {
+internal fun Map<String, Any?>.toQ42StatsApiFormat(): Map<String, Any?> {
     val fireStoreMap = this.mapValues { entry ->
         mapFieldValue(entry)
     }
@@ -10,7 +10,7 @@ internal fun Map<String, Any>.toQ42StatsApiFormat(): Map<String, Any> {
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun mapFieldValue(entry: Map.Entry<String, Any>): Any =
-    ((entry.value as? Map<String, Serializable>)
+private fun mapFieldValue(entry: Map.Entry<String, Any?>?): Any =
+    ((entry?.value as? Map<String, Serializable>)
         ?.toQ42StatsApiFormat() // if this is a map, recurse
-        ?: entry.value.toString()) // else, stringify the value
+        ?: entry?.value.toString()) // else, stringify the value

--- a/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
@@ -8,10 +8,10 @@ import java.io.Serializable
  *  a different hash, not being equal in comparisons etc.
  */
 internal fun Map<String, Any>.toQ42StatsApiFormat(): Map<String, Any> {
-    val fireStoreMap = this.mapValues { entry ->
+    val q42StatsMap = this.mapValues { entry ->
         mapFieldValue(entry)
     }
-    return fireStoreMap
+    return q42StatsMap
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
@@ -1,13 +1,12 @@
 package com.q42.q42stats.library
 
-import org.json.JSONObject
 import java.io.Serializable
 
-internal fun Map<String, Any>.toQ42StatsApiFormat(): JSONObject {
+internal fun Map<String, Any>.toQ42StatsApiFormat(): Map<String, Any> {
     val fireStoreMap = this.mapValues { entry ->
         mapFieldValue(entry)
     }
-    return JSONObject(fireStoreMap)
+    return fireStoreMap
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
@@ -2,6 +2,11 @@ package com.q42.q42stats.library
 
 import java.io.Serializable
 
+/** Returns a version of the input where all values are stringified
+ *  We do this to prevent serialize -> deserialize issues where the float 1.0 is transformed to 1,
+ *  for example. (this change is undesirable because the changed data type causes the object to have
+ *  a different hash, not being equal in comparisons etc.
+ */
 internal fun Map<String, Any>.toQ42StatsApiFormat(): Map<String, Any> {
     val fireStoreMap = this.mapValues { entry ->
         mapFieldValue(entry)

--- a/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/util/ApiFormatUtil.kt
@@ -2,7 +2,7 @@ package com.q42.q42stats.library
 
 import java.io.Serializable
 
-internal fun Map<String, Any?>.toQ42StatsApiFormat(): Map<String, Any?> {
+internal fun Map<String, Any>.toQ42StatsApiFormat(): Map<String, Any> {
     val fireStoreMap = this.mapValues { entry ->
         mapFieldValue(entry)
     }
@@ -10,7 +10,7 @@ internal fun Map<String, Any?>.toQ42StatsApiFormat(): Map<String, Any?> {
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun mapFieldValue(entry: Map.Entry<String, Any?>?): Any =
-    ((entry?.value as? Map<String, Serializable>)
+private fun mapFieldValue(entry: Map.Entry<String, Any>): Any =
+    ((entry.value as? Map<String, Serializable>)
         ?.toQ42StatsApiFormat() // if this is a map, recurse
-        ?: entry?.value.toString()) // else, stringify the value
+        ?: entry.value.toString()) // else, stringify the value

--- a/q42stats/src/main/java/com/q42/q42stats/library/util/SerializationUtil.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/util/SerializationUtil.kt
@@ -1,0 +1,24 @@
+package com.q42.q42stats.library.util
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal fun serializeMeasurement(value: Map<String, Any?>) =
+    JSONObject(value).toString()
+
+internal fun deserializeMeasurement(it: String): Map<String, Any?> =
+    JSONObject(it).toMap()
+
+private fun JSONObject.toMap(): Map<String, Any?> = keys().asSequence().associateWith {
+    when (val value = this[it]) {
+        is JSONArray -> {
+            val map = (0 until value.length()).associate { Pair(it.toString(), value[it]) }
+            JSONObject(map).toMap().values.toList()
+        }
+        is JSONObject -> value.toMap()
+        JSONObject.NULL -> null
+        else -> {
+            value
+        }
+    }
+}

--- a/q42stats/src/test/java/com/q42/q42stats/library/ApiFormatUtilTest.kt
+++ b/q42stats/src/test/java/com/q42/q42stats/library/ApiFormatUtilTest.kt
@@ -7,9 +7,10 @@ class ApiFormatUtilTest {
     @Test
     fun testToQ42StatsApiFormat() {
         val expected =
-            """{"screen width":"360","textScale":"1.6","language":"nl","currentMeasurement":{"createdAt":"1337"},"talkbackEnabled":"true"}"""
+            """{"screen width":"360","fontSize":"1.0","textScale":"1.6","language":"nl","currentMeasurement":{"createdAt":"1337"},"talkbackEnabled":"true"}"""
         val actual = mapOf(
             "screen width" to 360,
+            "fontSize" to 1.0, // expected is "1.0". should not be truncated to "1"
             "textScale" to 1.6,
             "talkbackEnabled" to true,
             "language" to "nl",

--- a/q42stats/src/test/java/com/q42/q42stats/library/ApiFormatUtilTest.kt
+++ b/q42stats/src/test/java/com/q42/q42stats/library/ApiFormatUtilTest.kt
@@ -1,5 +1,7 @@
 package com.q42.q42stats.library
 
+import com.q42.q42stats.library.util.deserializeMeasurement
+import com.q42.q42stats.library.util.serializeMeasurement
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -18,6 +20,26 @@ class ApiFormatUtilTest {
                 "createdAt" to 1337L
             )
         ).toQ42StatsApiFormat().toString()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testQ42StatsFormatCanBeSymmetricallySerialized() {
+        val expected =
+            """{"screen width":"360","fontSize":"1.0","textScale":"1.6","language":"nl","currentMeasurement":{"createdAt":"1337"},"talkbackEnabled":"true"}"""
+        val dataMap = mapOf(
+            "screen width" to 360,
+            "fontSize" to 1.0, // expected is "1.0". should not be truncated to "1"
+            "textScale" to 1.6,
+            "talkbackEnabled" to true,
+            "language" to "nl",
+            "currentMeasurement" to mapOf(
+                "createdAt" to 1337L
+            )
+        )
+        val statsFormat = dataMap.toQ42StatsApiFormat()
+        val jsonString = serializeMeasurement(statsFormat)
+        val actual = deserializeMeasurement(jsonString)
         assertEquals(expected, actual)
     }
 }

--- a/q42stats/src/test/java/com/q42/q42stats/library/ApiFormatUtilTest.kt
+++ b/q42stats/src/test/java/com/q42/q42stats/library/ApiFormatUtilTest.kt
@@ -1,15 +1,10 @@
 package com.q42.q42stats.library
 
-import com.q42.q42stats.library.util.deserializeMeasurement
-import com.q42.q42stats.library.util.serializeMeasurement
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ApiFormatUtilTest {
     @Test
     fun testToQ42StatsApiFormat() {
-        val expected =
-            """{"screen width":"360","fontSize":"1.0","textScale":"1.6","language":"nl","currentMeasurement":{"createdAt":"1337"},"talkbackEnabled":"true"}"""
         val actual = mapOf(
             "screen width" to 360,
             "fontSize" to 1.0, // expected is "1.0". should not be truncated to "1"
@@ -19,27 +14,21 @@ class ApiFormatUtilTest {
             "currentMeasurement" to mapOf(
                 "createdAt" to 1337L
             )
-        ).toQ42StatsApiFormat().toString()
-        assertEquals(expected, actual)
+        ).toQ42StatsApiFormat()
+
+        testQ42StatsMap(actual)
     }
 
-    @Test
-    fun testQ42StatsFormatCanBeSymmetricallySerialized() {
-        val expected =
-            """{"screen width":"360","fontSize":"1.0","textScale":"1.6","language":"nl","currentMeasurement":{"createdAt":"1337"},"talkbackEnabled":"true"}"""
-        val dataMap = mapOf(
-            "screen width" to 360,
-            "fontSize" to 1.0, // expected is "1.0". should not be truncated to "1"
-            "textScale" to 1.6,
-            "talkbackEnabled" to true,
-            "language" to "nl",
-            "currentMeasurement" to mapOf(
-                "createdAt" to 1337L
-            )
-        )
-        val statsFormat = dataMap.toQ42StatsApiFormat()
-        val jsonString = serializeMeasurement(statsFormat)
-        val actual = deserializeMeasurement(jsonString)
-        assertEquals(expected, actual)
+    private fun testQ42StatsMap(actual: Map<*, *>) {
+        actual.forEach {
+            when (it.value) {
+                is Map<*, *> -> {
+                    testQ42StatsMap(it.value as Map<*, *>)
+                }
+                else -> {
+                    assert(it.value is String) { "Expected $it to have a string type but was ${it.value}" }
+                }
+            }
+        }
     }
 }

--- a/q42stats/src/test/java/com/q42/q42stats/library/util/SerializationUtilKtTest.kt
+++ b/q42stats/src/test/java/com/q42/q42stats/library/util/SerializationUtilKtTest.kt
@@ -1,0 +1,24 @@
+package com.q42.q42stats.library.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SerializationUtilKtTest {
+
+    @Test
+    fun `Deserializing a serialized map results in an equal Map`() {
+        val expected = mapOf(
+            "screen width" to "360",
+            "fontSize" to "1.0", // expected is "1.0". should not be truncated to "1"
+            "numWheels" to "1",
+            "talkbackEnabled" to "true",
+            "language" to "nl",
+            "currentMeasurement" to mapOf(
+                "createdAt" to "1337L"
+            )
+        )
+        val serialized = serializeMeasurement(expected)
+        val actual = deserializeMeasurement(serialized)
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
This is a fix for the following report:

Er lijkt iets mis te gaan met floats die worden opgeslagen; die lijken bij het 2e request (als het een heel getal is), mee te komen als ints.
Voorbeeld:
Request 1:
```

[{
  "currentMeasurement": {
    "stats_timestamp": "1659170023",
    "stats_version": "3",
    [...]
    "screen_display_scale": "1.0",
    "screen_font_scale": "1.3",
    [...]
  },
  "previousMeasurement": {
    [...]
  },
  "current_hash": "958590475721473949",
  "previous_hash": "-7286425919675154353"
}] 
```
Volgende request:
```
[{
  "currentMeasurement": {
    [...]
  },
  "previousMeasurement": {
    "stats_timestamp": "1659170023",
    "stats_version": "3",
    [...]
    "screen_display_scale": "1",
    "screen_font_scale": "1.3",
    [...]
  },
  "current_hash": "958590475721473949",
  "previous_hash": "4637581908925368762"
}]
```
De 1.0 is veranderd naar 1. Daardoor is onze hash value anders. En daardoor wordt het voor ons lastig om requests van een zelfde type gebruiker aan elkaar te matchen.