### PR TITLE
feature / screen size 📱 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,30 +80,40 @@ versions of Android. If unsupported, the corresponding key is omitted.
 ### Accessibliity
 
 | Key | Value | Notes |
-|-|-|-| 
+|-|-|-|
 | `isClosedCaptioningEnabled` | bool | Live transcription of any spoken audio (minSdk >= 19) |
-| `isTouchExplorationEnabled` | bool | Whether any assistive feature is enabled where the user navigates the interface by touch. Most probably TalkBack, or similar
+| `isTouchExplorationEnabled` | bool | Whether any assistive feature is enabled where the user
+navigates the interface by touch. Most probably TalkBack, or similar
 | `isTalkBackEnabled` | bool | iOS: VoiceOver
-| `isSamsungTalkBackEnabled` | bool | Specifically checks whether com.samsung.android.app.talkback.talkbackservice is enabled
+| `isSamsungTalkBackEnabled` | bool | Specifically checks whether
+com.samsung.android.app.talkback.talkbackservice is enabled
 | `isSelectToSpeakEnabled` | bool | iOS: Speak Selection
 | `isSwitchAccessEnabled` | bool | Control the device by a switch such as a foot pedal
 | `isBrailleBackEnabled` | bool | Navigate the screen with an external Braille display
 | `isVoiceAccessEnabled` | bool | iOS: Voice Control
-| `fontScale` | float | Default value depends on device model. Some devices have a default font scaling of 1.1, for example |
-| `fontWeightAdjustment` | float | Default value is: 0. When bold text is enabled this value is greater than 0 (minSdk >= 31). Known issue: Always returns 0 on Samsung |
-| `displayScale` | float | Overall interface scaling ie. display density scaling. Default value may depend on device model (minSdk >= 24)|
-| `isMagnificationEnabled` | bool | Whether magnification is enabled (more specifically, whether magnification shortcuts are enabled) (minSdk >= 17). |
+| `fontScale` | float | Default value depends on device model. Some devices have a default font
+scaling of 1.1, for example |
+| `fontWeightAdjustment` | float | Default value is: 0. When bold text is enabled this value is
+greater than 0 (minSdk >= 31). Known issue: Always returns 0 on Samsung |
+| `displayScale` | float | Overall interface scaling ie. display density scaling. Default value may
+depend on device model (minSdk >= 24)|
+| `isMagnificationEnabled` | bool | Whether magnification is enabled (more specifically, whether
+magnification shortcuts are enabled) (minSdk >= 17). |
 | `isColorInversionEnabled` | bool | Available starting from Android 5.0 (>=21) |
 | `isColorBlindModeEnabled` | bool | |
-| `isHighTextContrastEnabled` | bool | When enabled, all text has a thin outline. Available starting from Android 5.0 (>=21)  |
-| `isAnimationsDisabled` | bool | Can be disabled pre-Android 9 (<28) through Developer Options, starting from Android 9 possible to any user (minSdk >= 19). |
-| `enabledAccessibilityServices` | Array\<String\> | List of enabled accessibility package names, eg ['com.accessibility.service1', 'nl.accessibility.service2'] |
+| `isHighTextContrastEnabled` | bool | When enabled, all text has a thin outline. Available starting
+from Android 5.0 (>=21)  |
+| `isAnimationsDisabled` | bool | Can be disabled pre-Android 9 (<28) through Developer Options,
+starting from Android 9 possible to any user (minSdk >= 19). |
+| `enabledAccessibilityServices` | Array\<String\> | List of enabled accessibility package names,
+eg ['com.accessibility.service1', 'nl.accessibility.service2'] |
 
 ### Preferences
 
 | Key | Value | Notes |
 |-|-|-|
-| `daytime`| day, twilight, night, unknown | Coarse estimation of time of day. unknown if user is not in Amsterdam TimeZone
+| `daytime`| day, twilight, night, unknown | Coarse estimation of time of day. unknown if user is
+not in Amsterdam TimeZone
 | `isNightModeEnabled` | bool | iOS: Dark Mode (minSdk: 29)
 
 ### Screen
@@ -111,18 +121,24 @@ versions of Android. If unsupported, the corresponding key is omitted.
 | Key | Value | Notes |
 |-|-|-|
 | `screenOrientation`| portrait, landscape, unknown |
-| `screenWidth` | String | Screen width in density-independent pixels and portrait mode.  |
+| `screenWidth` | String | Screen width in density-independent pixels. Beware: this value is
+different when there is a different screen orientation. |
+| `screenHeight` | String | Screen height in density-independent pixels. Beware: this value is
+different when there is a different screen orientation. |
 
 ### System
 
 | Key | Value | Notes |
 |-|-|-|
-| `applicationId` | String | identifier for the app for which data is collected, as set in the app's Manifest. iOS: bundleId | nl.hema.mobiel |
-| `defaultLanguage`| en-GB, nl-BE, nl, ... | If the country part (-BE) is not available, the value is just the language part ("nl")
-| `sdkVersion` | int | 29 for Android 10. [See this list](https://source.android.com/setup/start/build-numbers)
+| `applicationId` | String | identifier for the app for which data is collected, as set in the app's
+Manifest. iOS: bundleId | nl.hema.mobiel |
+| `defaultLanguage`| en-GB, nl-BE, nl, ... | If the country part (-BE) is not available, the value
+is just the language part ("nl")
+| `sdkVersion` | int | 29 for Android
+10. [See this list](https://source.android.com/setup/start/build-numbers)
 |`manufacturer`|String|eg. `samsung`|
-|`modelName`|String| May be a marketing name, but more often an internal code name. eg. `SM-G980F` for a particular variant of a Samsung Galaxy S10|
-
+|`modelName`|String| May be a marketing name, but more often an internal code name. eg. `SM-G980F`
+for a particular variant of a Samsung Galaxy S10|
 
 ## Development
 
@@ -136,7 +152,8 @@ exceptions don't crash the implementing apps.
 Catch Throwable; not Exception. Since Throwabl is the superclass of Exception, this will make the
 lib more resilient to crashes.
 
-For accessibility properties we want to track but could not find a property for, see [DOCUMENTATION.md](DOCUMENTATION.md)
+For accessibility properties we want to track but could not find a property for,
+see [DOCUMENTATION.md](DOCUMENTATION.md)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ versions of Android. If unsupported, the corresponding key is omitted.
 | Key | Value | Notes |
 |-|-|-|
 | `screenOrientation`| portrait, landscape, unknown |
+| `screenSize` | String | Screen size in density-independent pixels and portrait mode.  |
 
 ### System
 

--- a/README.md
+++ b/README.md
@@ -80,40 +80,30 @@ versions of Android. If unsupported, the corresponding key is omitted.
 ### Accessibliity
 
 | Key | Value | Notes |
-|-|-|-|
+|-|-|-| 
 | `isClosedCaptioningEnabled` | bool | Live transcription of any spoken audio (minSdk >= 19) |
-| `isTouchExplorationEnabled` | bool | Whether any assistive feature is enabled where the user
-navigates the interface by touch. Most probably TalkBack, or similar
+| `isTouchExplorationEnabled` | bool | Whether any assistive feature is enabled where the user navigates the interface by touch. Most probably TalkBack, or similar
 | `isTalkBackEnabled` | bool | iOS: VoiceOver
-| `isSamsungTalkBackEnabled` | bool | Specifically checks whether
-com.samsung.android.app.talkback.talkbackservice is enabled
+| `isSamsungTalkBackEnabled` | bool | Specifically checks whether com.samsung.android.app.talkback.talkbackservice is enabled
 | `isSelectToSpeakEnabled` | bool | iOS: Speak Selection
 | `isSwitchAccessEnabled` | bool | Control the device by a switch such as a foot pedal
 | `isBrailleBackEnabled` | bool | Navigate the screen with an external Braille display
 | `isVoiceAccessEnabled` | bool | iOS: Voice Control
-| `fontScale` | float | Default value depends on device model. Some devices have a default font
-scaling of 1.1, for example |
-| `fontWeightAdjustment` | float | Default value is: 0. When bold text is enabled this value is
-greater than 0 (minSdk >= 31). Known issue: Always returns 0 on Samsung |
-| `displayScale` | float | Overall interface scaling ie. display density scaling. Default value may
-depend on device model (minSdk >= 24)|
-| `isMagnificationEnabled` | bool | Whether magnification is enabled (more specifically, whether
-magnification shortcuts are enabled) (minSdk >= 17). |
+| `fontScale` | float | Default value depends on device model. Some devices have a default font scaling of 1.1, for example |
+| `fontWeightAdjustment` | float | Default value is: 0. When bold text is enabled this value is greater than 0 (minSdk >= 31). Known issue: Always returns 0 on Samsung |
+| `displayScale` | float | Overall interface scaling ie. display density scaling. Default value may depend on device model (minSdk >= 24)|
+| `isMagnificationEnabled` | bool | Whether magnification is enabled (more specifically, whether magnification shortcuts are enabled) (minSdk >= 17). |
 | `isColorInversionEnabled` | bool | Available starting from Android 5.0 (>=21) |
 | `isColorBlindModeEnabled` | bool | |
-| `isHighTextContrastEnabled` | bool | When enabled, all text has a thin outline. Available starting
-from Android 5.0 (>=21)  |
-| `isAnimationsDisabled` | bool | Can be disabled pre-Android 9 (<28) through Developer Options,
-starting from Android 9 possible to any user (minSdk >= 19). |
-| `enabledAccessibilityServices` | Array\<String\> | List of enabled accessibility package names,
-eg ['com.accessibility.service1', 'nl.accessibility.service2'] |
+| `isHighTextContrastEnabled` | bool | When enabled, all text has a thin outline. Available starting from Android 5.0 (>=21)  |
+| `isAnimationsDisabled` | bool | Can be disabled pre-Android 9 (<28) through Developer Options, starting from Android 9 possible to any user (minSdk >= 19). |
+| `enabledAccessibilityServices` | Array\<String\> | List of enabled accessibility package names, eg ['com.accessibility.service1', 'nl.accessibility.service2'] |
 
 ### Preferences
 
 | Key | Value | Notes |
 |-|-|-|
-| `daytime`| day, twilight, night, unknown | Coarse estimation of time of day. unknown if user is
-not in Amsterdam TimeZone
+| `daytime`| day, twilight, night, unknown | Coarse estimation of time of day. unknown if user is not in Amsterdam TimeZone
 | `isNightModeEnabled` | bool | iOS: Dark Mode (minSdk: 29)
 
 ### Screen
@@ -121,24 +111,19 @@ not in Amsterdam TimeZone
 | Key | Value | Notes |
 |-|-|-|
 | `screenOrientation`| portrait, landscape, unknown |
-| `screenWidth` | String | Screen width in density-independent pixels. Beware: this value is
-different when there is a different screen orientation. |
-| `screenHeight` | String | Screen height in density-independent pixels. Beware: this value is
-different when there is a different screen orientation. |
+| `screenWidth` | String | Screen width in density-independent pixels. Beware: this value is different when there is a different screen orientation.  |
+| `screenHeight` | String | Screen height in density-independent pixels. Beware: this value is different when there is a different screen orientation. |
 
 ### System
 
 | Key | Value | Notes |
 |-|-|-|
-| `applicationId` | String | identifier for the app for which data is collected, as set in the app's
-Manifest. iOS: bundleId | nl.hema.mobiel |
-| `defaultLanguage`| en-GB, nl-BE, nl, ... | If the country part (-BE) is not available, the value
-is just the language part ("nl")
-| `sdkVersion` | int | 29 for Android
-10. [See this list](https://source.android.com/setup/start/build-numbers)
+| `applicationId` | String | identifier for the app for which data is collected, as set in the app's Manifest. iOS: bundleId | nl.hema.mobiel |
+| `defaultLanguage`| en-GB, nl-BE, nl, ... | If the country part (-BE) is not available, the value is just the language part ("nl")
+| `sdkVersion` | int | 29 for Android 10. [See this list](https://source.android.com/setup/start/build-numbers)
 |`manufacturer`|String|eg. `samsung`|
-|`modelName`|String| May be a marketing name, but more often an internal code name. eg. `SM-G980F`
-for a particular variant of a Samsung Galaxy S10|
+|`modelName`|String| May be a marketing name, but more often an internal code name. eg. `SM-G980F` for a particular variant of a Samsung Galaxy S10|
+
 
 ## Development
 
@@ -152,8 +137,7 @@ exceptions don't crash the implementing apps.
 Catch Throwable; not Exception. Since Throwabl is the superclass of Exception, this will make the
 lib more resilient to crashes.
 
-For accessibility properties we want to track but could not find a property for,
-see [DOCUMENTATION.md](DOCUMENTATION.md)
+For accessibility properties we want to track but could not find a property for, see [DOCUMENTATION.md](DOCUMENTATION.md)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ versions of Android. If unsupported, the corresponding key is omitted.
 | Key | Value | Notes |
 |-|-|-|
 | `screenOrientation`| portrait, landscape, unknown |
-| `screenSize` | String | Screen size in density-independent pixels and portrait mode.  |
+| `screenWidth` | String | Screen width in density-independent pixels and portrait mode.  |
 
 ### System
 

--- a/q42stats/src/main/java/com/q42/q42stats/library/Q42Stats.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/Q42Stats.kt
@@ -19,7 +19,7 @@ internal const val TAG = "Q42Stats"
  * Version code for the data format that is sent to the server. Increment by 1 every time
  * you add / remove / change a field in any of the Collector classes
  */
-internal const val DATA_MODEL_VERSION = 4
+internal const val DATA_MODEL_VERSION = 5
 
 class Q42Stats(private val config: Q42StatsConfig) {
 

--- a/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
@@ -6,9 +6,11 @@ import android.content.Context.ACCESSIBILITY_SERVICE
 import android.content.Context.CAPTIONING_SERVICE
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
+import android.graphics.Point
 import android.os.Build
 import android.provider.Settings
 import android.util.DisplayMetrics
+import android.view.WindowManager
 import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.CaptioningManager
 import androidx.annotation.RequiresApi
@@ -82,7 +84,7 @@ internal object AccessibilityCollector {
                 )
             }
         }
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             put(
                 "isAnimationsDisabled",
                 isAnimationsDisabled(context)
@@ -101,6 +103,12 @@ internal object AccessibilityCollector {
                 }
             })
 
+        getScreenSize(context)?.let {
+            put(
+                "screenSize",
+                it
+            )
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             getSystemIntAsBool(
@@ -146,7 +154,7 @@ internal object AccessibilityCollector {
      */
     @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     private fun isMagnificationEnabled(context: Context, serviceNames: List<String>): Boolean? = try {
-        val isMagnificationByTripleTapGesturesEnabled = getSystemIntAsBool(context,"accessibility_display_magnification_enabled") ?: false
+        val isMagnificationByTripleTapGesturesEnabled = getSystemIntAsBool(context, "accessibility_display_magnification_enabled") ?: false
         val isMagnificationByVolumeButtonsEnabled = serviceNames.map { s -> s.lowercase() }.contains("com.example.android.apis.accessibility.magnificationservice")
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -154,11 +162,11 @@ internal object AccessibilityCollector {
                 Settings.Secure.getString(context.contentResolver, "accessibility_button_targets").lowercase().contains("com.android.server.accessibility.magnificationcontroller")
 
             isMagnificationByTripleTapGesturesEnabled || isMagnificationByVolumeButtonsEnabled || isMagnificationByNavigationButtonEnabled
-        }else{
+        } else {
             isMagnificationByTripleTapGesturesEnabled || isMagnificationByVolumeButtonsEnabled
         }
     } catch (e: Throwable) {
-        Q42StatsLogger.e(TAG, "Could not read magnification. Returning null", e)
+        Q42StatsLogger.w(TAG, "Could not read magnification, user likely has never used magnification before. Returning null.")
         null
     }
 
@@ -180,5 +188,55 @@ internal object AccessibilityCollector {
     } catch (e: Throwable) {
         Q42StatsLogger.e(TAG, "Could not read system int $name. Returning null", e)
         null
+    }
+
+    /**
+     * Gets the screen size in density independent pixels with portrait orientation.
+     *
+     * Note: calculates size given portrait mode.
+     */
+    private fun getScreenSize(context: Context): Pair<Int, Int>? {
+        return try {
+            val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+            val resources = context.resources
+
+            // get screen size in pixels
+            val pixelScreenSize = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val windowMetrics = windowManager.currentWindowMetrics
+                with(windowMetrics.bounds) {
+                    Pair(right, bottom)
+                }
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                val point = Point()
+                @Suppress("DEPRECATION")
+                windowManager.defaultDisplay.getRealSize(point)
+                Pair(point.x, point.y)
+            } else {
+                with(resources.displayMetrics) {
+                    Pair(widthPixels, heightPixels)
+                }
+            }
+
+            // get screen size in portrait mode
+            val portraitScreenSize = with(pixelScreenSize) {
+                if (resources.configuration.orientation == ORIENTATION_LANDSCAPE) {
+                    Pair(second, first)
+                } else {
+                    Pair(first, second)
+                }
+            }
+
+            val portraitDpScreenSize = with(portraitScreenSize) {
+                val density = resources.displayMetrics.density
+                Pair(
+                    (first / density).toInt(),
+                    (second / density).toInt()
+                )
+            }
+            portraitDpScreenSize
+        } catch (e: Throwable) {
+            Q42StatsLogger.e(TAG, "Could not read screen size. Returning null", e)
+            null
+        }
     }
 }

--- a/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
@@ -106,7 +106,11 @@ internal object AccessibilityCollector {
         getScreenSize(context)?.let {
             put(
                 "screenWidth",
-                it
+                it.first
+            )
+            put(
+                "screenHeight",
+                it.second
             )
         }
 
@@ -195,7 +199,7 @@ internal object AccessibilityCollector {
      *
      * Note: calculates size given portrait mode.
      */
-    private fun getScreenSize(context: Context): Int? {
+    private fun getScreenSize(context: Context): Pair<Int, Int>? {
         return try {
             val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
             val resources = context.resources
@@ -217,18 +221,12 @@ internal object AccessibilityCollector {
                 }
             }
 
-            // get screen size in portrait mode
-            val portraitScreenSize = with(pixelScreenSize) {
-                if (resources.configuration.orientation == ORIENTATION_LANDSCAPE) {
-                    second
-                } else {
-                    first
-                }
-            }
-
-            val portraitDpScreenSize = with(portraitScreenSize) {
+            val portraitDpScreenSize = with(pixelScreenSize) {
                 val density = resources.displayMetrics.density
-                (this / density).toInt()
+                Pair(
+                    (first / density).toInt(),
+                    (second / density).toInt()
+                )
             }
             portraitDpScreenSize
         } catch (e: Throwable) {

--- a/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
+++ b/q42stats/src/main/java/com/q42/q42stats/library/collector/AccessibilityCollector.kt
@@ -105,7 +105,7 @@ internal object AccessibilityCollector {
 
         getScreenSize(context)?.let {
             put(
-                "screenSize",
+                "screenWidth",
                 it
             )
         }
@@ -195,7 +195,7 @@ internal object AccessibilityCollector {
      *
      * Note: calculates size given portrait mode.
      */
-    private fun getScreenSize(context: Context): Pair<Int, Int>? {
+    private fun getScreenSize(context: Context): Int? {
         return try {
             val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
             val resources = context.resources
@@ -220,18 +220,15 @@ internal object AccessibilityCollector {
             // get screen size in portrait mode
             val portraitScreenSize = with(pixelScreenSize) {
                 if (resources.configuration.orientation == ORIENTATION_LANDSCAPE) {
-                    Pair(second, first)
+                    second
                 } else {
-                    Pair(first, second)
+                    first
                 }
             }
 
             val portraitDpScreenSize = with(portraitScreenSize) {
                 val density = resources.displayMetrics.density
-                Pair(
-                    (first / density).toInt(),
-                    (second / density).toInt()
-                )
+                (this / density).toInt()
             }
             portraitDpScreenSize
         } catch (e: Throwable) {


### PR DESCRIPTION
Gets screen size in density-independent pixels and portrait mode 📱 

Tested on:
✅ Android 13: S22+ / Fold 4
✅ Android 12: S10e
✅ Android 11: emulator
✅ Android 10: device
✅ Android 9: device
✅ Android 8: device
✅ Android 7: emulator
✅ Android 6: emulator
✅ Android 5: emulator